### PR TITLE
Fixed and verified sign bug in _perm_tables

### DIFF
--- a/diffusion_geometry/utils/basis_utils.py
+++ b/diffusion_geometry/utils/basis_utils.py
@@ -365,7 +365,7 @@ def _perm_tables(d: int, k: int):
         signs = np.ones((P,), dtype=np.int8)
     else:
         cmp = base_perms[:, :, None] > base_perms[:, None, :]  # (P,k,k) boolean
-        tri = np.tril_indices(k, k=-1)
+        tri = np.triu_indices(k, k=1)
         inv = np.sum(cmp[:, tri[0], tri[1]], axis=1)  # (P,)
         signs = np.where((inv & 1) == 0, 1, -1).astype(np.int8)
 


### PR DESCRIPTION
Addresses issue 19. Verified fix against a brute-force inversion count for k = 1…6: the triu version reproduces the true sign for every permutation, while the current tril version equals `(-1)^(k(k-1)/2)` times the true sign.

In particular the example in the issue:

```
from diffusion_geometry.utils.basis_utils import _perm_tables
import numpy as np
_, perms, signs = _perm_tables(3, 2)
perms, signs
(array([[0, 1], [1, 0]]), array([1,  -1], dtype=int8))

```
close #19 