### PR TITLE
Add explicit fixed bandwidth option

### DIFF
--- a/diffusion_geometry/core/diffusion/diffusion_process.py
+++ b/diffusion_geometry/core/diffusion/diffusion_process.py
@@ -106,7 +106,12 @@ def tune_kernel(kernel_entries: np.ndarray, epsilons: np.ndarray):
 
 
 def markov_chain(
-    nbr_distances, nbr_indices, c=0, bandwidth_variability=-0.5, knn_bandwidth=8
+    nbr_distances,
+    nbr_indices,
+    c=0,
+    bandwidth_variability=-0.5,
+    knn_bandwidth=8,
+    fixed_bandwidth=None,
 ):
     """
     Computes the diffusion kernel using a specific Markov chain construction.
@@ -127,6 +132,9 @@ def markov_chain(
         0 for fixed (standard Gaussian), -0.5 for variable (Diffusion Maps).
     knn_bandwidth : int
         Number of NNs for bandwidth estimation.
+    fixed_bandwidth : float, optional
+        Explicit Gaussian length scale. When provided, automatic bandwidth
+        estimation and tuning are skipped.
 
     Returns
     -------
@@ -140,6 +148,30 @@ def markov_chain(
 
     n, knn_kernel = nbr_distances.shape
     assert nbr_indices.shape == (n, knn_kernel)
+
+    if fixed_bandwidth is not None:
+        try:
+            fixed_bandwidth = float(fixed_bandwidth)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "fixed_bandwidth must be a positive finite scalar"
+            ) from exc
+        if not np.isfinite(fixed_bandwidth) or fixed_bandwidth <= 0:
+            raise ValueError("fixed_bandwidth must be a positive finite scalar")
+
+        kernel = np.exp(-(nbr_distances**2) / fixed_bandwidth**2)
+        density_estimate = kernel.sum(axis=1)
+        alpha = 1 - c / 2
+        density_estimate_alpha = density_estimate**(-alpha)
+        kernel_alpha = kernel * (
+            density_estimate_alpha[:, None]
+            * density_estimate_alpha[nbr_indices]
+        )
+        row_sums = kernel_alpha.sum(axis=1)
+        diffusion_kernel = kernel_alpha / row_sums[:, None]
+        bandwidths = np.full(n, fixed_bandwidth**2 / 4)
+
+        return diffusion_kernel, bandwidths
 
     # 1. Compute the kernel bandwidths rho via kernel density estimation.
 

--- a/diffusion_geometry/core/geometry/diffusion_geometry.py
+++ b/diffusion_geometry/core/geometry/diffusion_geometry.py
@@ -216,6 +216,7 @@ class DiffusionGeometry:
         cls,
         nbr_indices: np.ndarray,
         nbr_distances: np.ndarray,
+        fixed_bandwidth: Optional[float] = None,
         **kwargs,
     ) -> "DiffusionGeometry":
         """
@@ -236,6 +237,7 @@ class DiffusionGeometry:
             - c (float, default=0.0): Parameter for Markov chain construction.
             - bandwidth_variability (float, default=-0.5): Parameter for bandwidth variability.
             - knn_bandwidth (int, default=8): Number of neighbours for bandwidth estimation.
+            - fixed_bandwidth (float, optional): Explicit Gaussian length scale.
             - rcond (float, default=1e-5): Cutoff for spectral operations.
             - measure (np.ndarray, optional): Stationary measure.
             - function_basis (np.ndarray, optional): Precomputed basis of coefficient functions.
@@ -247,6 +249,7 @@ class DiffusionGeometry:
             c=kwargs.get("c", 0.0),
             bandwidth_variability=kwargs.get("bandwidth_variability", -0.5),
             knn_bandwidth=kwargs.get("knn_bandwidth", 8),
+            fixed_bandwidth=fixed_bandwidth,
         )
         immersion_coords = kwargs.pop("immersion_coords", None)
 
@@ -262,6 +265,7 @@ class DiffusionGeometry:
     def from_point_cloud(
         cls,
         data_matrix: np.ndarray,
+        fixed_bandwidth: Optional[float] = None,
         **kwargs,
     ) -> "DiffusionGeometry":
         """
@@ -280,6 +284,7 @@ class DiffusionGeometry:
             - c (float, default=0.0): Parameter for Markov chain construction.
             - bandwidth_variability (float, default=-0.5): Parameter for bandwidth variability.
             - knn_bandwidth (int, default=8): Number of neighbours for bandwidth estimation.
+            - fixed_bandwidth (float, optional): Explicit Gaussian length scale.
             - regularisation_method (str, default='diffusion'): Regularisation method.
             - rcond (float, default=1e-5): Cutoff for spectral operations.
             - measure (np.ndarray, optional): Stationary measure.
@@ -294,6 +299,7 @@ class DiffusionGeometry:
         return cls.from_knn_graph(
             nbr_indices=nbr_indices,
             nbr_distances=nbr_distances,
+            fixed_bandwidth=fixed_bandwidth,
             **kwargs,
         )
 

--- a/tests/test_classes/test_constructors.py
+++ b/tests/test_classes/test_constructors.py
@@ -4,6 +4,7 @@ import pytest
 import scipy.sparse as sp
 
 from diffusion_geometry.core import DiffusionGeometry, knn_graph, markov_chain
+import diffusion_geometry.core.diffusion.diffusion_process as diffusion_process
 
 
 def _build_knn_inputs(n=96, d=4, knn_kernel=24, knn_bandwidth=8):
@@ -28,6 +29,102 @@ def _assert_valid_geometry(dg, data_shape):
     assert np.isfinite(dg.immersion_coords).all()
     assert np.isfinite(dg.measure).all()
     assert np.isfinite(dg.function_basis).all()
+
+
+def test_markov_chain_fixed_bandwidth_uses_requested_gaussian_scale(monkeypatch):
+    nbr_distances = np.array([[0.0, 1.0], [0.0, 2.0]])
+    nbr_indices = np.array([[0, 1], [1, 0]])
+    fixed_bandwidth = 2.0
+    c = 0.5
+
+    monkeypatch.setattr(
+        diffusion_process,
+        "compute_local_bandwidths",
+        lambda *_args, **_kwargs: pytest.fail("automatic bandwidth estimation ran"),
+    )
+    monkeypatch.setattr(
+        diffusion_process,
+        "tune_kernel",
+        lambda *_args, **_kwargs: pytest.fail("automatic bandwidth tuning ran"),
+    )
+
+    kernel, bandwidths = markov_chain(
+        nbr_distances=nbr_distances,
+        nbr_indices=nbr_indices,
+        c=c,
+        fixed_bandwidth=fixed_bandwidth,
+    )
+
+    unnormalised = np.exp(-(nbr_distances**2) / fixed_bandwidth**2)
+    density = unnormalised.sum(axis=1)
+    alpha = 1 - c / 2
+    expected = unnormalised * (
+        density[:, None] ** (-alpha) * density[nbr_indices] ** (-alpha)
+    )
+    expected /= expected.sum(axis=1, keepdims=True)
+
+    np.testing.assert_allclose(kernel, expected)
+    np.testing.assert_allclose(bandwidths, fixed_bandwidth**2 / 4)
+
+
+def test_markov_chain_explicit_none_matches_automatic_default():
+    _, nbr_distances, nbr_indices, _, _ = _build_knn_inputs(
+        n=32, d=3, knn_kernel=12, knn_bandwidth=4
+    )
+
+    default_kernel, default_bandwidths = markov_chain(
+        nbr_distances=nbr_distances,
+        nbr_indices=nbr_indices,
+    )
+    none_kernel, none_bandwidths = markov_chain(
+        nbr_distances=nbr_distances,
+        nbr_indices=nbr_indices,
+        fixed_bandwidth=None,
+    )
+
+    np.testing.assert_allclose(none_kernel, default_kernel)
+    np.testing.assert_allclose(none_bandwidths, default_bandwidths)
+
+
+@pytest.mark.parametrize("fixed_bandwidth", [0, -1, np.nan, np.inf])
+def test_markov_chain_rejects_invalid_fixed_bandwidth(fixed_bandwidth):
+    nbr_distances = np.array([[0.0, 1.0], [0.0, 2.0]])
+    nbr_indices = np.array([[0, 1], [1, 0]])
+
+    with pytest.raises(ValueError, match="fixed_bandwidth must be a positive finite scalar"):
+        markov_chain(
+            nbr_distances=nbr_distances,
+            nbr_indices=nbr_indices,
+            fixed_bandwidth=fixed_bandwidth,
+        )
+
+
+@pytest.mark.parametrize("constructor", ["point_cloud", "knn_graph"])
+def test_constructors_forward_fixed_bandwidth(constructor):
+    data, nbr_distances, nbr_indices, _, _ = _build_knn_inputs(
+        n=32, d=3, knn_kernel=12, knn_bandwidth=4
+    )
+    fixed_bandwidth = 0.2
+
+    if constructor == "point_cloud":
+        dg = DiffusionGeometry.from_point_cloud(
+            data_matrix=data,
+            fixed_bandwidth=fixed_bandwidth,
+            knn_kernel=12,
+            n_function_basis=10,
+        )
+    else:
+        dg = DiffusionGeometry.from_knn_graph(
+            nbr_indices=nbr_indices,
+            nbr_distances=nbr_distances,
+            fixed_bandwidth=fixed_bandwidth,
+            data_matrix=data,
+            n_function_basis=10,
+        )
+
+    np.testing.assert_allclose(
+        dg.triple._cdc.keywords["bandwidths"], fixed_bandwidth**2 / 4
+    )
 
 
 @pytest.mark.parametrize("regularisation_method", ["diffusion", "bandlimit", "none"])


### PR DESCRIPTION
## Summary
- add `fixed_bandwidth` to point-cloud and kNN constructors
- bypass automatic bandwidth estimation/tuning for the explicit Gaussian scale
- return constant CDC bandwidths of `h^2 / 4` with validation and coverage

## Verification
- `./.venv312/bin/python -m pytest tests/test_classes/test_constructors.py -q`
- `./.venv312/bin/python -m pytest -q`
- 419 passed, 67 skipped

Fixes #21